### PR TITLE
Convert negatives to strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Cash
+**This is a fork of [github.com/zelcon5/cash](https://github.com/zelcon5/cash) with added support for negatives.**
+
+## Cash
 
 A realistic money library for Go aka Golang. There is no BigDecimal equivalent for Go, so I found myself using integral cents for money. This library offers convenience by making "money" or "cash" a real type.
 
-Money is internally stored as cents (`int64`s).
+Money is internally stored as cents (`int64` string).
 
 Heavy inspiration from Martin Fowler's "Quantity" object

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 A realistic money library for Go aka Golang. There is no BigDecimal equivalent for Go, so I found myself using integral cents for money. This library offers convenience by making "money" or "cash" a real type.
 
-Money is internally stored as cents (`int64` string).
+Money is internally stored as cents (`int64`).
 
 Heavy inspiration from Martin Fowler's "Quantity" object

--- a/cash.go
+++ b/cash.go
@@ -115,16 +115,27 @@ func roundLikeBankers(x int64) int64 {
 
 // SetString() on already allocated `Cash`
 func (z *Cash) SetString(src string) (*Cash, error) {
+	var neg bool = false
+	src = strings.Replace(src, "$", "", 1)
+	src = strings.Replace(src, ",", "", -1)
+	if strings.HasPrefix(src, "(") { // negative
+		z.Amt = z.Amt * -1
+		src = strings.Replace(src, "(", "", 1)
+		src = strings.Replace(src, ")", "", 1)
+		neg = true
+	}
 	var (
 		parts = strings.Split(src, string(z.Decimal))
 		err   error
 	)
-
 	switch len(parts) {
 	case 1: // just an integer
 		z.Amt, err = strconv.ParseInt(src, 10, 64)
 		if err != nil {
 			return nil, err
+		}
+		if neg {
+			z.Amt = z.Amt * -1
 		}
 		return z, nil
 	case 2: // decimal
@@ -149,6 +160,9 @@ func (z *Cash) SetString(src string) (*Cash, error) {
 			fracPart = roundLikeBankers(fracPart)
 		}
 		z.Amt = integerPart + fracPart
+		if neg {
+			z.Amt = z.Amt * -1
+		}
 		return z, nil
 	default:
 		return nil, ErrBadString

--- a/cash.go
+++ b/cash.go
@@ -168,10 +168,16 @@ func (z *Cash) String() string {
 		buf         bytes.Buffer
 		integerPart string
 		fracPart    string
+		neg         bool
 	)
 
-	buf.WriteRune(z.Currency) // dollar sign
+	if z.IsPositive() != true {
+		neg=true
+		z.Amt = z.Amt * -1 // make positive
+		buf.WriteString("(")
+	}
 
+	buf.WriteRune(z.Currency) // dollar sign
 	// decimal
 	decRaw := strconv.FormatInt(z.Amt, 10)
 	decRawLen := utf8.RuneCountInString(decRaw)
@@ -207,6 +213,11 @@ func (z *Cash) String() string {
 	buf.WriteString(integerPart) // write left side of decimal pt
 	buf.WriteRune(z.Decimal)     // decimal point
 	buf.WriteString(fracPart)    // write right side of decimal pt
+
+	if neg {
+		buf.WriteString(")")
+		z.Amt = z.Amt * -1 // make negative
+	}
 
 	return buf.String()
 }

--- a/cash_test.go
+++ b/cash_test.go
@@ -154,3 +154,15 @@ func TestCmp(t *testing.T) {
 	assert.Nil(t, err)
 	assert.EqualValues(t, false, is, "a != b so a.Equals(b) == false")
 }
+
+func TestRoundTrip(t *testing.T) {
+	expected := New(USD).SetCents(1001897)
+	actual, err := New(USD).SetString(expected.String())
+	assert.Nil(t, err)
+	assert.EqualValues(t, expected.Amt, actual.Amt)
+
+	expected = New(USD).SetCents(-1001897)
+	actual, err = New(USD).SetString(expected.String())
+	assert.Nil(t, err)
+	assert.EqualValues(t, expected.Amt, actual.Amt)
+}


### PR DESCRIPTION
```Go
package main

import (
	"fmt"
	"github.com/zelcon5/cash"
)

func main() {
	var m *cash.Cash

	m = cash.NewUSD().SetCents(1200)
	fmt.Println(m.String())

	m = cash.NewUSD().SetCents(-1200)
	fmt.Println(m.String())
}
```
Currently prints:
```
$12.00
$,-12.00
```

Corrected with my pull request:

```
$12.00
($12.00)
```